### PR TITLE
multiple hostnames and specified ports

### DIFF
--- a/dnsToIp-ufw.sh
+++ b/dnsToIp-ufw.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 # dns to ip and check it's in ufw rules
-#
 
-HOSTNAME=yourHostname
+# Hostnames separated by space
+# Ports separated by: , (comma)
+
+HOSTNAMES='host1.duckdns.org host2.duckdns.org'
+PORTS='1234, 4567'
 
 if [[ $EUID -ne 0 ]]; then
    echo "This script must be run as root"
    exit 1
 fi
 
-new_ip=$(host $HOSTNAME | grep -oP '(\d+\.){3}\d+')
-old_ip=$(/usr/sbin/ufw status | grep -oP '(\d+\.){3}\d+\/tcp' | sed 's/\/tcp.*//g')
-
-if [ "$new_ip" = "$old_ip" ] ; then
-    echo IP address has not changed
-else
+for HOST in ${HOSTNAMES}
+do
+  new_ip=$(host $HOST | grep -oP '(\d+\.){3}\d+')
+  old_ip=$(/usr/sbin/ufw status | grep $HOST | grep -oP '(\d+\.){3}\d+')
+  #echo debug $old_ip, $new_ip
+  if [ "$new_ip" != "$old_ip" ] ; then
     if [ -n "$old_ip" ] ; then
-        /usr/sbin/ufw delete allow from $old_ip to any
-        echo iptables cleaned from old ip
+      echo /usr/sbin/ufw delete allow proto tcp from $new_ip to any port $PORTS comment "$HOST"
     fi
-    /usr/sbin/ufw allow from $new_ip to any proto tcp
-    echo iptables have been updated with $new_ip
-fi
+      echo /usr/sbin/ufw allow proto tcp from $new_ip to any port $PORTS comment "$HOST"
+    echo "ufw $HOST has been updated with $new_ip (was $old_ip) for ports: $PORTS"
+  #else
+  #  echo IP address has not changed
+  fi
+done

--- a/dnsToIp-ufw.sh
+++ b/dnsToIp-ufw.sh
@@ -8,22 +8,28 @@ HOSTNAMES='host1.duckdns.org host2.duckdns.org'
 PORTS='1234, 4567'
 
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root"
-   exit 1
+  echo "This script must be run as root"
+  exit 1
 fi
 
 for HOST in ${HOSTNAMES}
 do
   new_ip=$(host $HOST | grep -oP '(\d+\.){3}\d+')
   old_ip=$(/usr/sbin/ufw status | grep $HOST | grep -oP '(\d+\.){3}\d+')
+
   #echo debug $old_ip, $new_ip
+
   if [ "$new_ip" != "$old_ip" ] ; then
+
     if [ -n "$old_ip" ] ; then
       echo /usr/sbin/ufw delete allow proto tcp from $new_ip to any port $PORTS comment "$HOST"
     fi
-      echo /usr/sbin/ufw allow proto tcp from $new_ip to any port $PORTS comment "$HOST"
+
+    echo /usr/sbin/ufw allow proto tcp from $new_ip to any port $PORTS comment "$HOST"
     echo "ufw $HOST has been updated with $new_ip (was $old_ip) for ports: $PORTS"
+  
+  # for a longer report in syslogs
   #else
-  #  echo IP address has not changed
+  #  echo IP addresKs has not changed
   fi
 done


### PR DESCRIPTION
I needed to open just a few ports for a few dynamic hosts so I changed the script to be able to do this
I also made it more silent, only echo if it actually replaced the ufw rule


My ufw commands are prefixed with "echo" ... Because If you accept my request it requires that the old rules be deleted by the old script and i haven't thought about how to do this yet so i try to make mine do nothing except echo what it would do. 

thanks for reviewing my request 
